### PR TITLE
Remove unnecessary indirection

### DIFF
--- a/counter_mutex.go
+++ b/counter_mutex.go
@@ -3,12 +3,12 @@ package counter
 import "sync"
 
 type MutexCounter struct {
-	mu     *sync.RWMutex
+	mu     sync.RWMutex
 	number uint64
 }
 
 func NewMutexCounter() Counter {
-	return &MutexCounter{&sync.RWMutex{}, 0}
+	return &MutexCounter{}
 }
 
 func (c *MutexCounter) Add(num uint64) {


### PR DESCRIPTION
The zero value for sync.RWMutex is usable without initialisation. It is not necessary to use a pointer to a mutex, a value will suffice.